### PR TITLE
minor changes to remove lucrasoft.nl specific config values

### DIFF
--- a/src/KeyHub.Integration.Tests/issues.txt
+++ b/src/KeyHub.Integration.Tests/issues.txt
@@ -5,8 +5,6 @@
 
   - upgrade to entity framework 6.0?
 
-  - lucrasoft.nl is in the codebase in a few places
-
   - what to do about usernames that are in the sourcecode?
     - have a default admin and warn people to change it
     - require an appSetting with the admin email, require OpenID login

--- a/src/KeyHub.Web/Api/Controllers/TransactionController.cs
+++ b/src/KeyHub.Web/Api/Controllers/TransactionController.cs
@@ -34,7 +34,7 @@ namespace KeyHub.Web.Api.Controllers
         ///     Host: localhost:63436
         ///     Content-Length: 185
         ///     Content-Type: application/xml
-        ///     <TransactionRequest PurchaserName="Steven Somer" PurchaserEmail="steven@lucrasoft.nl">
+        ///     <TransactionRequest PurchaserName="Steven Somer" PurchaserEmail="steven@example.org">
         ///         <PurchasedSku>{guid}</PurchasedSku>
         ///     </TransactionRequest>
         /// </example> 

--- a/src/KeyHub.Web/Controllers/MailController.cs
+++ b/src/KeyHub.Web/Controllers/MailController.cs
@@ -48,14 +48,8 @@ namespace KeyHub.Web.Controllers
         /// <returns>Emailmessage ready to be set to purchaser</returns>
         public EmailResult TransactionEmail(TransactionMailViewModel model)
         {
-            bool redirectMails = (WebConfigurationManager.AppSettings["redirectMails"] !=null) && bool.Parse(WebConfigurationManager.AppSettings["redirectMails"]);
-            string redirectTo = WebConfigurationManager.AppSettings["redirectTo"];
-
-            if (redirectMails && string.IsNullOrEmpty(redirectTo))
-                throw new ConfigurationErrorsException("Mail redirecting enabled without a RedirectTo set");
-
-            To.Add(redirectMails ? redirectTo : model.PurchaserEmail);
-            From = "no-reply@lucrasoft.nl";
+            To.Add(model.PurchaserEmail);
+            From = ConfigurationManager.AppSettings["siteNoReplyEmailAddress"];
             Subject = "Please claim your transaction.";
             return Email("NewTransactionEmail", model);
         }
@@ -67,14 +61,8 @@ namespace KeyHub.Web.Controllers
         /// <returns>Emailmessage ready to be set to purchaser</returns>
         public EmailResult IssueEmail(IssueMailViewModel model)
         {
-            bool redirectMails = (WebConfigurationManager.AppSettings["redirectMails"] != null) && bool.Parse(WebConfigurationManager.AppSettings["redirectMails"]);
-            string redirectTo = WebConfigurationManager.AppSettings["redirectTo"];
-
-            if (redirectMails && string.IsNullOrEmpty(redirectTo))
-                throw new ConfigurationErrorsException("Mail redirecting enabled without a RedirectTo set");
-
-            To.Add(redirectMails ? redirectTo : model.Email);
-            From = "no-reply@lucrasoft.nl";
+            To.Add(model.Email);
+            From = ConfigurationManager.AppSettings["siteNoReplyEmailAddress"];
             Subject = "An issue occured on you application.";
             return Email("IssueEmail", model);
         }

--- a/src/KeyHub.Web/Web.config
+++ b/src/KeyHub.Web/Web.config
@@ -37,15 +37,14 @@
     <add key="twitterConsumerSecret" value="" />
     <add key="facebookAppId" value="" />
     <add key="facebookAppSecret" value="" />
-    <add key="redirectMails" value="true" />
-    <add key="redirectTo" value="floris@lucrasoft.nl" />
-    <add key="smtpServer" value="ntlucra6" />
+    <add key="smtpServer" value="localhost" />
     <add key="smtpServerPort" value="25" />
     <add key="elmah.mvc.disableHandler" value="false" />
     <add key="elmah.mvc.disableHandleErrorFilter" value="false" />
     <add key="elmah.mvc.requiresAuthentication" value="true" />
     <add key="elmah.mvc.allowedRoles" value="Sys_Administrator" />
     <add key="elmah.mvc.route" value="elmah" />
+    <add key="siteNoReplyEmailAddress" value="no-reply@example.com"/>
     <!-- DatabaseEncryptionKey must have the same values across any server accessing the same database -->
     <add key="DatabaseEncryptionKey" value="This password is used when storing some sensitive information"/>
   </appSettings>


### PR DESCRIPTION
The original commit message had this justification for removing redirectMails/redirectTo
- Configuration settings redirectMails/redirectTo were removed.  This config settings were made to allow testing email with a real mailserver without mailing a real user.

That approach had the downside of hard-coding a configuration useful only to past developers.
A better approach is for localhost to try and use localhost as an email server.  By doing that, integration tests can run a fake server to test behavior.  Developers can run a localhost mailserver for manual testing (fake or not, something like http://smtp4dev.codeplex.com/ is best).
