### PR TITLE
add url rewrite rules to redirect production traffic http -> https

### DIFF
--- a/src/KeyHub.Web/Web.Release.config
+++ b/src/KeyHub.Web/Web.Release.config
@@ -27,5 +27,19 @@
         <error statusCode="500" redirect="InternalError.htm"/>
       </customErrors>
     -->
+    <httpCookies xdt:Transform="Insert" requireSSL="true" />
   </system.web>
+  <system.webServer>
+    <rewrite xdt:Transform="Insert">
+      <rules>
+        <rule name="Redirect to HTTPS" stopProcessing="true">
+          <match url="(.*)" />
+          <conditions>
+            <add input="{HTTPS}" pattern="^OFF$" />
+          </conditions>
+          <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
 </configuration>


### PR DESCRIPTION
  This should address issue 34 / https://github.com/imazen/keyhub/issues/34

  I try to minimize differences between production and testing environments that might invalidate testing, so I spent some time seeing if we could make SSL the default for development too.  In this case though, forcing developers to using SSL is tough because the Url Rewrite rules don't know how to choose the port that IIS Express will use for SSL, and IIS Express configuration is not in source control (the configuration is per-machine, even enabling IIS Express in the first place).
